### PR TITLE
feat: use subject &  services instead of emits

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,6 +10,8 @@ import { RecipeItemComponent } from './recipes/recipes-list/recipe-item/recipe-i
 import { ShoppingEditComponent } from './shopping-list/shopping-edit/shopping-edit.component';
 import { ShoppingListComponent } from './shopping-list/shopping-list.component';
 import { DropdownDirective } from './shared/dropdown.directive';
+import { RecipeService } from './recipes/recipe.service';
+import { ShoppingListService } from './shopping-list/shopping-list.service';
 
 @NgModule({
   declarations: [
@@ -24,7 +26,7 @@ import { DropdownDirective } from './shared/dropdown.directive';
     DropdownDirective,
   ],
   imports: [BrowserModule],
-  providers: [],
+  providers: [RecipeService, ShoppingListService],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/src/app/recipes/recipe-detail/recipe-detail.component.html
+++ b/src/app/recipes/recipe-detail/recipe-detail.component.html
@@ -1,37 +1,39 @@
-<div class="row">
-  <div class="col-xs-12">
-    <img src="{{ recipe.imageURL }}" alt="" class="img-responsive" height="300" />
-  </div>
-</div>
-
-<div class="row">
-  <div class="col-xs-12">
-    <h1>{{ recipe.name }}</h1>
-  </div>
-</div>
-
-<div class="row">
-  <div class="col-xs-12">
-    <div class="btn-group" appDropdown>
-      <button class="btn btn-primary dropdown-toggle">
-        Manage Recipe
-        <span class="caret"></span>
-      </button>
-
-      <ul class="dropdown-menu open">
-        <li><a href="#">To Shopping List</a></li>
-        <li><a href="#">Edit Recipe</a></li>
-        <li><a href="#">Delete Recipe</a></li>
-      </ul>
+<ng-container *ngIf="selectedRecipe$ | async as recipe">
+  <div class="row">
+    <div class="col-xs-12">
+      <img src="{{ recipe.imageURL }}" alt="" class="img-responsive" height="300" />
     </div>
   </div>
-</div>
 
-<div class="row">
-  <div class="col-xs-6">Description</div>
-  <div class="col-xs-6">{{ recipe?.description }}</div>
-</div>
+  <div class="row">
+    <div class="col-xs-12">
+      <h1>{{ recipe.name }}</h1>
+    </div>
+  </div>
 
-<div class="row">
-  <div class="col-xs-12">Ingredient</div>
-</div>
+  <div class="row">
+    <div class="col-xs-12">
+      <div class="btn-group" appDropdown>
+        <button class="btn btn-primary dropdown-toggle">
+          Manage Recipe
+          <span class="caret"></span>
+        </button>
+
+        <ul class="dropdown-menu open">
+          <li><a href="#">To Shopping List</a></li>
+          <li><a href="#">Edit Recipe</a></li>
+          <li><a href="#">Delete Recipe</a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-xs-6">Description</div>
+    <div class="col-xs-6">{{ recipe?.description }}</div>
+  </div>
+
+  <div class="row">
+    <div class="col-xs-12">Ingredient</div>
+  </div>
+</ng-container>

--- a/src/app/recipes/recipe-detail/recipe-detail.component.ts
+++ b/src/app/recipes/recipe-detail/recipe-detail.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { Recipe } from '../recipe.model';
+import { RecipeService } from '../recipe.service';
 
 @Component({
   selector: 'app-recipe-detail',
@@ -7,9 +8,9 @@ import { Recipe } from '../recipe.model';
   styleUrls: ['./recipe-detail.component.css'],
 })
 export class RecipeDetailComponent implements OnInit {
-  @Input() recipe: Recipe;
+  constructor(private recipeService: RecipeService) {}
 
-  constructor() {}
+  selectedRecipe$ = this.recipeService.selectedRecipe$;
 
   ngOnInit(): void {}
 }

--- a/src/app/recipes/recipe.service.ts
+++ b/src/app/recipes/recipe.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Subject, shareReplay } from 'rxjs';
+import { Recipe } from './recipe.model';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class RecipeService {
+  constructor() {}
+
+  private recipesSubject = new BehaviorSubject<Recipe[]>([
+    new Recipe(
+      'Test Recipe 1',
+      'This is simply a Test 1',
+      'https://images.immediate.co.uk/production/volatile/sites/30/2022/08/Chicken-Tikka-99647a6.jpg?quality=90&resize=556,505'
+    ),
+    new Recipe(
+      'Test Recipe 2',
+      'This is simply a Test 2',
+      'https://images.immediate.co.uk/production/volatile/sites/30/2022/08/Chicken-Tikka-99647a6.jpg?quality=90&resize=556,505'
+    ),
+  ]);
+
+  recipes$ = this.recipesSubject.pipe(
+    shareReplay(1) // This is to avoid multiple subscriptions to the same observable
+  );
+
+  private selectedRecipeSubject = new Subject<Recipe>();
+  selectedRecipe$ = this.selectedRecipeSubject.pipe(shareReplay(1));
+
+  addRecipe(recipe: Recipe) {
+    this.recipesSubject.next([...this.recipesSubject.value, recipe]);
+  }
+
+  selectRecipe(recipe: Recipe) {
+    this.selectedRecipeSubject.next(recipe);
+  }
+}

--- a/src/app/recipes/recipe.service.ts
+++ b/src/app/recipes/recipe.service.ts
@@ -1,11 +1,11 @@
-import { Injectable } from '@angular/core';
+import { Injectable, OnDestroy } from '@angular/core';
 import { BehaviorSubject, Subject, shareReplay } from 'rxjs';
 import { Recipe } from './recipe.model';
 
 @Injectable({
   providedIn: 'root',
 })
-export class RecipeService {
+export class RecipeService implements OnDestroy {
   constructor() {}
 
   private recipesSubject = new BehaviorSubject<Recipe[]>([
@@ -27,6 +27,11 @@ export class RecipeService {
 
   private selectedRecipeSubject = new Subject<Recipe>();
   selectedRecipe$ = this.selectedRecipeSubject.pipe(shareReplay(1));
+
+  ngOnDestroy() {
+    this.recipesSubject.complete();
+    this.selectedRecipeSubject.complete();
+  }
 
   addRecipe(recipe: Recipe) {
     this.recipesSubject.next([...this.recipesSubject.value, recipe]);

--- a/src/app/recipes/recipe.service.ts
+++ b/src/app/recipes/recipe.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, OnDestroy } from '@angular/core';
-import { BehaviorSubject, Subject, shareReplay } from 'rxjs';
+import { BehaviorSubject, Subject, map, shareReplay } from 'rxjs';
 import { Recipe } from './recipe.model';
 
 @Injectable({
@@ -22,11 +22,15 @@ export class RecipeService implements OnDestroy {
   ]);
 
   recipes$ = this.recipesSubject.pipe(
-    shareReplay(1) // This is to avoid multiple subscriptions to the same observable
+    shareReplay(1), // This is to avoid multiple subscriptions to the same observable
+    map((recipes) => [...recipes])
   );
 
   private selectedRecipeSubject = new Subject<Recipe>();
-  selectedRecipe$ = this.selectedRecipeSubject.pipe(shareReplay(1));
+  selectedRecipe$ = this.selectedRecipeSubject.pipe(
+    shareReplay(1),
+    map((recipe) => ({ ...recipe }))
+  );
 
   ngOnDestroy() {
     this.recipesSubject.complete();

--- a/src/app/recipes/recipes-list/recipe-item/recipe-item.component.ts
+++ b/src/app/recipes/recipes-list/recipe-item/recipe-item.component.ts
@@ -1,3 +1,4 @@
+import { RecipeService } from './../../recipe.service';
 import { Output, Component, Input, OnInit, EventEmitter } from '@angular/core';
 import { Recipe } from '../../recipe.model';
 
@@ -7,14 +8,13 @@ import { Recipe } from '../../recipe.model';
   styleUrls: ['./recipe-item.component.css'],
 })
 export class RecipeItemComponent implements OnInit {
-  @Input() recipe: Recipe;
-  @Output() recipeSelected = new EventEmitter<Recipe>();
+  constructor(private recipeService: RecipeService) {}
 
-  constructor() {}
+  @Input() recipe: Recipe;
 
   ngOnInit(): void {}
 
   onRecipeSelection(recipe: Recipe) {
-    this.recipeSelected.emit(recipe);
+    this.recipeService.selectRecipe(recipe);
   }
 }

--- a/src/app/recipes/recipes-list/recipes-list.component.html
+++ b/src/app/recipes/recipes-list/recipes-list.component.html
@@ -5,7 +5,6 @@
 </div>
 
 <!-- {{ recipeNames$ | async | json }} -->
-<hr />
 <div class="row">
   <div class="col-xs-12">
     <app-recipe-item *ngFor="let recipe of recipes$ | async" [recipe]="recipe"></app-recipe-item>

--- a/src/app/recipes/recipes-list/recipes-list.component.html
+++ b/src/app/recipes/recipes-list/recipes-list.component.html
@@ -3,6 +3,8 @@
     <button class="btn btn-success">New Recipe</button>
   </div>
 </div>
+
+<!-- {{ recipeNames$ | async | json }} -->
 <hr />
 <div class="row">
   <div class="col-xs-12">

--- a/src/app/recipes/recipes-list/recipes-list.component.html
+++ b/src/app/recipes/recipes-list/recipes-list.component.html
@@ -6,10 +6,6 @@
 <hr />
 <div class="row">
   <div class="col-xs-12">
-    <app-recipe-item
-      *ngFor="let recipe of recipes"
-      [recipe]="recipe"
-      (recipeSelected)="recipeSelected.emit($event)"
-    ></app-recipe-item>
+    <app-recipe-item *ngFor="let recipe of recipes$ | async" [recipe]="recipe"></app-recipe-item>
   </div>
 </div>

--- a/src/app/recipes/recipes-list/recipes-list.component.ts
+++ b/src/app/recipes/recipes-list/recipes-list.component.ts
@@ -15,17 +15,25 @@ export class RecipesListComponent implements OnInit {
   // recipeNames$: Observable<string[] | undefined>;
 
   ngOnInit(): void {
-    // this.recipeNames$ = this.recipes$.pipe(
-    //   map((recipes, _index) => recipes.map((recipe) => recipe.name))
-    // );
-    // setTimeout(() => {
-    //   this.recipeService.addRecipe(
-    //     new Recipe(
-    //       'Test Recipe 3',
-    //       'This is simply a Test 3',
-    //       'https://images.immediate.co.uk/production/volatile/sites/30/2022/08/Chicken-Tikka-99647a6.jpg?quality=90&resize=556,505'
-    //     )
-    //   );
-    // }, 2000);
+    this.recipes$.pipe(map((recipes, _index) => recipes.map((recipe) => recipe.name))).subscribe(
+      (recipeNames) => {
+        console.log(recipeNames);
+      },
+      (error) => {
+        console.log(error);
+      },
+      () => {
+        console.log('Completed!');
+      }
+    );
+    setTimeout(() => {
+      this.recipeService.addRecipe(
+        new Recipe(
+          'Test Recipe 3',
+          'This is simply a Test 3',
+          'https://images.immediate.co.uk/production/volatile/sites/30/2022/08/Chicken-Tikka-99647a6.jpg?quality=90&resize=556,505'
+        )
+      );
+    }, 2000);
   }
 }

--- a/src/app/recipes/recipes-list/recipes-list.component.ts
+++ b/src/app/recipes/recipes-list/recipes-list.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, Output, EventEmitter } from '@angular/core';
 import { Recipe } from '../recipe.model';
 import { RecipeService } from '../recipe.service';
+import { Observable, map } from 'rxjs';
 
 @Component({
   selector: 'app-recipes-list',
@@ -8,9 +9,23 @@ import { RecipeService } from '../recipe.service';
   styleUrls: ['./recipes-list.component.css'],
 })
 export class RecipesListComponent implements OnInit {
-  constructor(private RecipeService: RecipeService) {}
+  constructor(private recipeService: RecipeService) {}
 
-  ngOnInit(): void {}
+  recipes$ = this.recipeService.recipes$;
+  // recipeNames$: Observable<string[] | undefined>;
 
-  recipes$ = this.RecipeService.recipes$;
+  ngOnInit(): void {
+    // this.recipeNames$ = this.recipes$.pipe(
+    //   map((recipes, _index) => recipes.map((recipe) => recipe.name))
+    // );
+    // setTimeout(() => {
+    //   this.recipeService.addRecipe(
+    //     new Recipe(
+    //       'Test Recipe 3',
+    //       'This is simply a Test 3',
+    //       'https://images.immediate.co.uk/production/volatile/sites/30/2022/08/Chicken-Tikka-99647a6.jpg?quality=90&resize=556,505'
+    //     )
+    //   );
+    // }, 2000);
+  }
 }

--- a/src/app/recipes/recipes-list/recipes-list.component.ts
+++ b/src/app/recipes/recipes-list/recipes-list.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, Output, EventEmitter } from '@angular/core';
 import { Recipe } from '../recipe.model';
+import { RecipeService } from '../recipe.service';
 
 @Component({
   selector: 'app-recipes-list',
@@ -7,21 +8,9 @@ import { Recipe } from '../recipe.model';
   styleUrls: ['./recipes-list.component.css'],
 })
 export class RecipesListComponent implements OnInit {
-  recipes: Recipe[] = [
-    new Recipe(
-      'Test Recipe 1',
-      'This is simply a Test 1',
-      'https://images.immediate.co.uk/production/volatile/sites/30/2022/08/Chicken-Tikka-99647a6.jpg?quality=90&resize=556,505'
-    ),
-    new Recipe(
-      'Test Recipe 2',
-      'This is simply a Test 2',
-      'https://images.immediate.co.uk/production/volatile/sites/30/2022/08/Chicken-Tikka-99647a6.jpg?quality=90&resize=556,505'
-    ),
-  ];
-  @Output() recipeSelected = new EventEmitter<Recipe>();
-
-  constructor() {}
+  constructor(private RecipeService: RecipeService) {}
 
   ngOnInit(): void {}
+
+  recipes$ = this.RecipeService.recipes$;
 }

--- a/src/app/recipes/recipes.component.html
+++ b/src/app/recipes/recipes.component.html
@@ -1,12 +1,12 @@
 <div class="row">
   <div class="col-md-5">
-    <app-recipes-list (recipeSelected)="recipeSelected($event)"></app-recipes-list>
+    <app-recipes-list></app-recipes-list>
   </div>
   <div class="col-md-7">
-    <app-recipe-detail
-      [recipe]="selectedRecipe"
-      *ngIf="selectedRecipe; else infoText"
-    ></app-recipe-detail>
+    <ng-container *ngIf="selectedRecipe$ | async; else infoText">
+      <app-recipe-detail></app-recipe-detail>
+    </ng-container>
+
     <ng-template #infoText>
       <div class="alert alert-info">Please select a recipe</div>
     </ng-template>

--- a/src/app/recipes/recipes.component.ts
+++ b/src/app/recipes/recipes.component.ts
@@ -1,3 +1,4 @@
+import { RecipeService } from './recipe.service';
 import { Component, OnInit } from '@angular/core';
 import { Recipe } from './recipe.model';
 
@@ -7,12 +8,9 @@ import { Recipe } from './recipe.model';
   styleUrls: ['./recipes.component.css'],
 })
 export class RecipesComponent implements OnInit {
-  selectedRecipe: Recipe;
-  constructor() {}
+  constructor(private recipeService: RecipeService) {}
 
   ngOnInit(): void {}
 
-  recipeSelected(recipe: Recipe) {
-    this.selectedRecipe = recipe;
-  }
+  selectedRecipe$ = this.recipeService.selectedRecipe$;
 }

--- a/src/app/recipes/recipes.component.ts
+++ b/src/app/recipes/recipes.component.ts
@@ -6,6 +6,7 @@ import { Recipe } from './recipe.model';
   selector: 'app-recipes',
   templateUrl: './recipes.component.html',
   styleUrls: ['./recipes.component.css'],
+  providers: [RecipeService],
 })
 export class RecipesComponent implements OnInit {
   constructor(private recipeService: RecipeService) {}

--- a/src/app/shopping-list/shopping-edit/shopping-edit.component.ts
+++ b/src/app/shopping-list/shopping-edit/shopping-edit.component.ts
@@ -1,3 +1,4 @@
+import { ShoppingListService } from './../shopping-list.service';
 import { Component, OnInit, ViewChild, ElementRef, EventEmitter, Output } from '@angular/core';
 import { Ingredient } from 'src/app/shared/ingredient.model';
 
@@ -9,9 +10,8 @@ import { Ingredient } from 'src/app/shared/ingredient.model';
 export class ShoppingEditComponent implements OnInit {
   @ViewChild('nameInput') nameInputRef: ElementRef<HTMLInputElement>;
   @ViewChild('amountInput') amountInputRef: ElementRef<HTMLInputElement>;
-  @Output() ingredientAdded = new EventEmitter<Ingredient>();
 
-  constructor() {}
+  constructor(private shoppingListService: ShoppingListService) {}
 
   ngOnInit(): void {}
 
@@ -20,6 +20,6 @@ export class ShoppingEditComponent implements OnInit {
     const name = this.nameInputRef.nativeElement.value;
     const amount = +this.amountInputRef.nativeElement.value;
     if (!name || !amount) return;
-    this.ingredientAdded.emit(new Ingredient(name, amount));
+    this.shoppingListService.addIngredient(new Ingredient(name, amount));
   }
 }

--- a/src/app/shopping-list/shopping-list.component.html
+++ b/src/app/shopping-list/shopping-list.component.html
@@ -1,13 +1,13 @@
 <div class="row">
   <div class="col-xs-10">
-    <app-shopping-edit (ingredientAdded)="ingredientAdded($event)"></app-shopping-edit>
+    <app-shopping-edit></app-shopping-edit>
     <hr />
     <ul class="list-group">
       <a
         href=""
         class="list-group-item"
         style="cursor: pointer"
-        *ngFor="let ingredient of ingredients"
+        *ngFor="let ingredient of ingredients$ | async"
       >
         {{ ingredient.name }} ({{ ingredient.amount }})
       </a>

--- a/src/app/shopping-list/shopping-list.component.ts
+++ b/src/app/shopping-list/shopping-list.component.ts
@@ -1,3 +1,4 @@
+import { ShoppingListService } from './shopping-list.service';
 import { Component, OnInit } from '@angular/core';
 import { Ingredient } from '../shared/ingredient.model';
 
@@ -7,13 +8,8 @@ import { Ingredient } from '../shared/ingredient.model';
   styleUrls: ['./shopping-list.component.css'],
 })
 export class ShoppingListComponent implements OnInit {
-  ingredients: Ingredient[] = [new Ingredient('Apples', 5), new Ingredient('Tomatoes', 10)];
-
-  constructor() {}
+  constructor(private shoppingListService: ShoppingListService) {}
+  ingredients$ = this.shoppingListService.ingredients$;
 
   ngOnInit(): void {}
-
-  ingredientAdded(ingredient: Ingredient) {
-    this.ingredients.push(ingredient);
-  }
 }

--- a/src/app/shopping-list/shopping-list.service.ts
+++ b/src/app/shopping-list/shopping-list.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import { Ingredient } from '../shared/ingredient.model';
+import { BehaviorSubject, shareReplay } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ShoppingListService {
+  private ingredientsSubject = new BehaviorSubject<Ingredient[]>([
+    new Ingredient('Apples', 5),
+    new Ingredient('Tomatoes', 10),
+  ]);
+
+  ingredients$ = this.ingredientsSubject.pipe(
+    shareReplay(1) // This is to avoid multiple subscriptions to the same observable
+  );
+
+  constructor() {}
+
+  addIngredient(ingredient: Ingredient) {
+    this.ingredientsSubject.next([...this.ingredientsSubject.value, ingredient]);
+  }
+}

--- a/src/app/shopping-list/shopping-list.service.ts
+++ b/src/app/shopping-list/shopping-list.service.ts
@@ -1,11 +1,11 @@
-import { Injectable } from '@angular/core';
+import { Injectable, OnDestroy } from '@angular/core';
 import { Ingredient } from '../shared/ingredient.model';
 import { BehaviorSubject, shareReplay } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
 })
-export class ShoppingListService {
+export class ShoppingListService implements OnDestroy {
   private ingredientsSubject = new BehaviorSubject<Ingredient[]>([
     new Ingredient('Apples', 5),
     new Ingredient('Tomatoes', 10),
@@ -16,6 +16,10 @@ export class ShoppingListService {
   );
 
   constructor() {}
+
+  ngOnDestroy(): void {
+    this.ingredientsSubject.complete();
+  }
 
   addIngredient(ingredient: Ingredient) {
     this.ingredientsSubject.next([...this.ingredientsSubject.value, ingredient]);


### PR DESCRIPTION
1. Instead of emiting `selectedRecipe` three times we use service to handle this  logic
2. instead of drilling the selectedRecipe to `recipe-details.component` we can just subscribe and reactively update the value
3. instead of drilling & emitting events to add ingredients we can use service with a bonus effort we can also add ingredients from recipes component.